### PR TITLE
Add --bump, --tag, and --tag-pattern options

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,36 @@ arguments.
 msync hook activate -n puppetlabs -b sync_branch
 ```
 
+### Updating metadata.json
+
+Modulesync can optionally bump the minor version in `metadata.json` for each
+modified modules if you add the `--bump` flag to the command line:
+
+```
+msync update -m "Commit message" --bump
+```
+
+#### Tagging repositories
+
+If you wish to tag the modified repositories with the newly bumped version,
+you can do so by using the `--tag` flag:
+
+```
+msync update -m "Commit message" --bump --tag
+```
+
+#### Setting the tag pattern
+
+You can also set the format of the tag to be used (`printf`-formatted)
+by setting the `tag_pattern` option:
+
+```
+msync update -m "Commit message" --bump --tag --tag_pattern 'v%s'
+```
+
+The default for the tag pattern is `%s`.
+
+
 The Templates
 -------------
 

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -82,7 +82,7 @@ module ModuleSync
         if options[:noop]
           Git.update_noop(puppet_module, options[:branch])
         else
-          Git.update(puppet_module, files_to_manage, options[:message], options[:branch])
+          Git.update(puppet_module, files_to_manage, options[:message], options[:branch], options[:bump], options[:tag], options[:tag_pattern])
         end
       end
     elsif options[:command] == 'hook'

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -14,6 +14,7 @@ module ModuleSync
         :git_provider_address => 'github.com',
         :managed_modules_conf => 'managed_modules.yml',
         :configs              => '.',
+        :tag_pattern          => '%s',
       }
     end
 
@@ -35,7 +36,7 @@ module ModuleSync
       @options.merge!(Hash.transform_keys_to_symbols(Util.parse_config(MODULESYNC_CONF_FILE)))
       @options[:command] = args[0] if commands_available.include?(args[0])
       opt_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--noop] [-n <namespace>] [-b <branch>] [-f <filter>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
+        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--noop] [--bump] [--tag] [--tag-pattern <tag_pattern>] [-n <namespace>] [-b <branch>] [-f <filter>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
         opts.on('-m', '--message <msg>',
                 'Commit message to apply to updated modules') do |msg|
           @options[:message] = msg
@@ -59,6 +60,18 @@ module ModuleSync
         opts.on('--noop',
                 'No-op mode') do |msg|
           @options[:noop] = true
+        end
+        opts.on('--bump',
+                'Bump module version to the next minor') do |msg|
+          @options[:bump] = true
+        end
+        opts.on('--tag',
+                'Git tag with the current module version') do |msg|
+          @options[:tag] = true
+        end
+        opts.on('--tag-pattern',
+                'The pattern to use when tagging releases.') do |pattern|
+          @options[:tag_pattern] = pattern
         end
         @options[:help] = opts.help
       end.parse!

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -1,4 +1,5 @@
 require 'git'
+require 'puppet_blacksmith'
 
 module ModuleSync
   module Git
@@ -27,9 +28,26 @@ module ModuleSync
       end
     end
 
+    def self.bump(repo, m)
+      new = m.bump!
+      puts "Bumped to version #{new}"
+      repo.add('metadata.json')
+      repo.commit("Release version #{new}")
+      repo.push
+      new
+    end
+
+    def self.tag(repo, version, tag_pattern)
+      tag = tag_pattern % version
+      puts "Tagging with #{tag}"
+      repo.add_tag(tag)
+      repo.push('origin', tag)
+    end
+
     # Git add/rm, git commit, git push
-    def self.update(name, files, message, branch)
-      repo = ::Git.open("#{PROJ_ROOT}/#{name}")
+    def self.update(name, files, message, branch, bump=false, tag=false, tag_pattern=nil)
+      module_root = "#{PROJ_ROOT}/#{name}"
+      repo = ::Git.open(module_root)
       repo.branch(branch).checkout
       files.each do |file|
         if repo.status.deleted.include?(file)
@@ -41,6 +59,12 @@ module ModuleSync
       begin
         repo.commit(message)
         repo.push('origin', branch)
+        # Only bump/tag if pushing didn't fail (i.e. there were changes)
+        m = Blacksmith::Modulefile.new("#{module_root}/metadata.json")
+        if bump
+          new = self.bump(repo, m)
+          self.tag(repo, new, tag_pattern) if tag
+        end
       rescue ::Git::GitExecuteError => git_error
         if git_error.message.include? "nothing to commit, working directory clean"
           puts "There were no files to update in #{name}. Not committing."

--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
 
   spec.add_runtime_dependency 'git', '~>1.2'
+  spec.add_runtime_dependency 'puppet-blacksmith', '~>3.0'
 end


### PR DESCRIPTION
This PR uses [`puppet-blacksmith`](https://github.com/maestrodev/puppet-blacksmith) to automate the following tasks:

* Bump minor version in `metadata.json` if files were changed
* Tag module with new version (using `v%s` by default, can be overridden with --tag-pattern)

This allows for bulk minor releases using msync.