### PR TITLE
Fix support for branches other than 'master'.

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -55,7 +55,7 @@ module ModuleSync
 
       managed_modules.each do |puppet_module|
         puts "Syncing #{puppet_module}"
-        Git.pull(options[:git_user], options[:git_provider_address], options[:namespace], puppet_module)
+        Git.pull(options[:git_user], options[:git_provider_address], options[:namespace], options[:branch], puppet_module)
         module_configs = Util.parse_config("#{PROJ_ROOT}/#{puppet_module}/#{MODULE_CONF_FILE}")
         files_to_manage = module_files | defaults.keys | module_configs.keys
         files_to_delete = []

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -48,7 +48,7 @@ module ModuleSync
         repo.commit(message)
         repo.push('origin', branch)
       rescue ::Git::GitExecuteError => git_error
-        if git_error.message.include? "nothing to commit, working directory clean"
+        if git_error.message.include? "nothing to commit (working directory clean)"
           puts "There were no files to update in #{name}. Not committing."
         else
           puts git_error


### PR DESCRIPTION
This seems to better support those of us who do not commit directly to the master branch.  I was having a terrible time with the code making a new branch instead of switching to the existing remote.  `repo.checkout(branch)` was the magic sauce.