### PR TITLE
Add a global config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ overridden or extended by adding a file called .sync.yml to the module itself.
 This allows us to, for example, have a set of "required" gems that are added
 to all Gemfiles, and a set of "optional" gems that a single module might add.
 
+Within the templates, values can be accessed in the `@configs` hash, which is
+merged from the values under the keys `:global` and the current file name.
+
 The list of modules to manage is in managed\_modules.yml in the configuration
 directory. This lists just the names of the modules to be managed.
 

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -59,10 +59,12 @@ module ModuleSync
         git_base = "#{options[:git_base]}#{options[:namespace]}"
         Git.pull(git_base, puppet_module, options[:branch], opts || {})
         module_configs = Util.parse_config("#{PROJ_ROOT}/#{puppet_module}/#{MODULE_CONF_FILE}")
-        files_to_manage = module_files | defaults.keys | module_configs.keys
+        global_defaults = defaults[GLOBAL_DEFAULTS_KEY] || {}
+        module_defaults = module_configs[GLOBAL_DEFAULTS_KEY] || {}
+        files_to_manage = (module_files | defaults.keys | module_configs.keys) - [GLOBAL_DEFAULTS_KEY]
         files_to_delete = []
         files_to_manage.each do |file|
-          file_configs = (defaults[file] || {}).merge(module_configs[file] || {})
+          file_configs = global_defaults.merge(defaults[file] || {}).merge(module_defaults).merge(module_configs[file] || {})
           file_configs[:puppet_module] = puppet_module
           if file_configs['unmanaged']
             puts "Not managing #{file} in #{puppet_module}"

--- a/lib/modulesync/constants.rb
+++ b/lib/modulesync/constants.rb
@@ -6,5 +6,6 @@ module ModuleSync
     MODULESYNC_CONF_FILE = 'modulesync.yml'
     PROJ_ROOT            = './modules'
     HOOK_FILE            = '.git/hooks/pre-push'
+    GLOBAL_DEFAULTS_KEY  = :global
   end
 end


### PR DESCRIPTION
Using the new :global entry in config_defaults.yml and .sync.yml,
data can be shared across files in a module.