### PR TITLE
Add support for Gerrit review system

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ found.
 msync update -m "Commit message"
 ```
 
+If the user decide to use a different branch than master, s/he might want to amend the commit based on users feedbacks.
+
+```
+msync update --amend
+```
+
+If a push --force is needed.
+
+```
+msync update --amend --force
+```
+
 #### Automating Updates
 
 You can install a pre-push git hook to automatically clone, update, and push
@@ -199,6 +211,35 @@ Then you can run ModuleSync without extra arguments:
 ```
 msync update --noop
 msync update -m "Commit message"
+```
+
+Available parameters for modulesync.yml
+
+* git_base : The default URL to git clone from (Default: 'git@github.com:')
+* namespace : Namespace of the projects to manage (Default: 'puppetlabs')
+* branch : Branch to push to (Default: 'master')
+* remote_branch : Remote branch to push to (Default: Same value as branch)
+* pre_commit_script : A script to be run before commiting (ie. contrib/myfooscript.sh)
+
+##### Example
+
+###### Github
+
+```
+---
+namespace: MySuperOrganization
+branch: modulesyncbranch
+```
+
+###### Gerrit
+
+```
+---
+namespace: stackforge
+git_base:  ssh://jdoe@review.openstack.org:29418/
+branch: msync_foo
+remote_branch: refs/publish/master/msync_foo
+pre_commit_script: openstack-commit-msg-hook.sh
 ```
 
 #### Filtering Repositories

--- a/contrib/openstack-commit-msg-hook.sh
+++ b/contrib/openstack-commit-msg-hook.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+commit_msg_path=$1/.git/hooks/commit-msg
+
+if [ ! -f $commit_msg_path ]; then
+  curl -s -Lo $commit_msg_path http://review.openstack.org/tools/hooks/commit-msg
+  chmod 775 $commit_msg_path
+fi

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -56,11 +56,7 @@ module ModuleSync
       # managed_modules is either an array or a hash
       managed_modules.each do |puppet_module, opts|
         puts "Syncing #{puppet_module}"
-        if options[:git_base]
-          git_base = options[:git_base]
-        else
-          git_base = "#{options[:git_user]}@#{options[:git_provider_address]}:#{options[:namespace]}"
-        end
+        git_base = "#{options[:git_base]}#{options[:namespace]}"
         Git.pull(git_base, puppet_module, options[:branch], opts || {})
         module_configs = Util.parse_config("#{PROJ_ROOT}/#{puppet_module}/#{MODULE_CONF_FILE}")
         files_to_manage = module_files | defaults.keys | module_configs.keys
@@ -80,9 +76,9 @@ module ModuleSync
         end
         files_to_manage -= files_to_delete
         if options[:noop]
-          Git.update_noop(puppet_module, options[:branch])
+          Git.update_noop(puppet_module, options)
         else
-          Git.update(puppet_module, files_to_manage, options[:message], options[:branch], options[:bump], options[:changelog], options[:tag], options[:tag_pattern])
+          Git.update(puppet_module, files_to_manage, options)
         end
       end
     elsif options[:command] == 'hook'

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -10,8 +10,7 @@ module ModuleSync
       {
         :namespace            => 'puppetlabs',
         :branch               => 'master',
-        :git_user             => 'git',
-        :git_provider_address => 'github.com',
+        :git_base             => 'git@github.com:',
         :managed_modules_conf => 'managed_modules.yml',
         :configs              => '.',
         :tag_pattern          => '%s',
@@ -57,6 +56,14 @@ module ModuleSync
                 'A regular expression to filter repositories to update.') do |filter|
           @options[:filter] = filter
         end
+        opts.on('--amend',
+                'Amend previous commit') do |msg|
+          @options[:amend] = true
+        end
+        opts.on('--force',
+                'Force push amended commit') do |msg|
+          @options[:force] = true
+        end
         opts.on('--noop',
                 'No-op mode') do |msg|
           @options[:noop] = true
@@ -81,7 +88,7 @@ module ModuleSync
       end.parse!
 
       @options.fetch(:message) do
-        if @options[:command] == 'update' && ! @options[:noop]
+        if @options[:command] == 'update' && ! @options[:noop] && ! @options[:amend]
           fail("A commit message is required unless using noop.")
         end
       end

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -64,10 +64,16 @@ module ModuleSync
     end
 
     # Git add/rm, git commit, git push
-    def self.update(name, files, message, branch, bump=false, changelog=false, tag=false, tag_pattern=nil)
+    def self.update(name, files, options)
       module_root = "#{PROJ_ROOT}/#{name}"
+      message = options[:message]
+      if options[:remote_branch]
+        branch = "#{options[:branch]}:#{options[:remote_branch]}"
+      else
+        branch = options[:branch]
+      end
       repo = ::Git.open(module_root)
-      repo.branch(branch).checkout
+      repo.branch(options[:branch]).checkout
       files.each do |file|
         if repo.status.deleted.include?(file)
           repo.remove(file)
@@ -76,13 +82,26 @@ module ModuleSync
         end
       end
       begin
-        repo.commit(message)
-        repo.push('origin', branch)
+        opts_commit = {}
+        opts_push = {}
+        if options[:amend]
+          opts_commit = {:amend => true}
+          message = nil
+        end
+        if options[:force]
+          opts_push = {:force => true}
+        end
+        if options[:pre_commit_script]
+          script = "#{File.dirname(File.dirname(__FILE__))}/../contrib/#{options[:pre_commit_script]}"
+          %x[#{script} #{module_root}]
+        end
+        repo.commit(message, opts_commit)
+        repo.push('origin', branch, opts_push)
         # Only bump/tag if pushing didn't fail (i.e. there were changes)
         m = Blacksmith::Modulefile.new("#{module_root}/metadata.json")
-        if bump
-          new = self.bump(repo, m, message, module_root, changelog)
-          self.tag(repo, new, tag_pattern) if tag
+        if options[:bump]
+          new = self.bump(repo, m, message, module_root, options[:changelog])
+          self.tag(repo, new, options[:tag_pattern]) if options[:tag]
         end
       rescue ::Git::GitExecuteError => git_error
         if git_error.message.include? "nothing to commit, working directory clean"
@@ -102,11 +121,11 @@ module ModuleSync
       repo.status.untracked.keep_if{|f,_| !ignored.any?{|i| File.fnmatch(i, f)}}
     end
 
-    def self.update_noop(name, branch)
+    def self.update_noop(name, options)
       puts "Using no-op. Files in #{name} may be changed but will not be committed."
 
       repo = ::Git.open("#{PROJ_ROOT}/#{name}")
-      repo.branch(branch).checkout
+      repo.branch(options[:branch]).checkout
 
       puts "Files changed: "
       repo.diff('HEAD', '--').each do |diff|


### PR DESCRIPTION
This commits add supports gerrit system and will submit a review
everytime a change is made on the same branch.

The `modulesync.yml` file looks like

```
---                                                                                                                                                              
namespace: stackforge
git_base:  ssh://jdoe@review.openstack.org:29418/
branch: msync_foo
branch_prefix: HEAD:refs/publish/master/
pre_commit_script: openstack-commit-msg-hook.sh

```

When a user receive a -1, the user can simply re-run `msync update --amend` and a new patchset will be submited
