### PR TITLE
Fix remote branch checkout

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -40,17 +40,20 @@ module ModuleSync
         switch_branch(repo, branch)
       # Repo already cloned, check out master and override local changes
       else
-        puts "Overriding any local changes to repositories in #{PROJ_ROOT}"
-        repo = ::Git.open("#{PROJ_ROOT}/#{name}")
-        repo.fetch
-        repo.reset_hard
-        if remote_branch_exists?(repo, branch)
-          switch_branch(repo, branch)
-          repo.pull('origin', branch)
-        else # git checkout -b branch origin/master
-          repo.checkout('origin/master')
-          puts "Creating new branch #{branch}"
-          repo.branch(branch).checkout
+        # Some versions of git can't properly handle managing a repo from outside the repo directory
+        Dir.chdir("#{PROJ_ROOT}/#{name}") do
+          puts "Overriding any local changes to repositories in #{PROJ_ROOT}"
+          repo = ::Git.open('.')
+          repo.fetch
+          repo.reset_hard
+          if remote_branch_exists?(repo, branch)
+              switch_branch(repo, branch)
+              repo.pull('origin', branch)
+          else # git checkout -b branch origin/master
+            repo.checkout('origin/master')
+            puts "Creating new branch #{branch}"
+            repo.branch(branch).checkout
+          end
         end
       end
     end


### PR DESCRIPTION
Currently, the user can specify a branch other than master to make
changes to, and modulesync will attempt to pull updates from that
branch before starting work. This is a problem because if the branch
does not exist remotely, the pull will fail.

This patch proposes the following workflow:

- If the repo is being cloned for the first time, check out the
  user-specified branch locally based on local master
- If the repo exists locally and the user-specified branch exists
  remotely, check out that branch locally and pull any changes from the
  remote branch before starting work.
- If the repo exists locally and the branch does not exist remotely,
  create a new branch based on origin/master.