### PR TITLE
Gitlab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 modules/
 *.gem
 Gemfile.lock
+modulesync.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-gem 'pry'
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
+gem 'pry'
+
 gemspec

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -56,6 +56,15 @@ module ModuleSync
       # managed_modules is either an array or a hash
       managed_modules.each do |puppet_module, opts|
         puts "Syncing #{puppet_module}"
+        case options[:git_provider]
+        when 'gitlab'
+          path = puppet_module.split('/')
+          module_namespace = path[0]
+          module_name = path[1]
+        else
+          module_namespace = options[:namespace]
+          module_name = puppet_module
+        end
         if options[:git_base]
           git_base = options[:git_base]
         else
@@ -66,7 +75,10 @@ module ModuleSync
         files_to_manage = module_files | defaults.keys | module_configs.keys
         files_to_delete = []
         files_to_manage.each do |file|
-          file_configs = (defaults[file] || {}).merge(module_configs[file] || {})
+          file_configs = (defaults[file] || {}).merge(module_configs[file] || {}).merge(
+            'module_name'      => module_name,
+            'module_namespace' => module_namespace
+            )
           if file_configs['unmanaged']
             puts "Not managing #{file} in #{puppet_module}"
             files_to_delete << file

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'fileutils'
 require 'modulesync/cli'
 require 'modulesync/constants'

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'fileutils'
 require 'modulesync/cli'
 require 'modulesync/constants'

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -11,6 +11,7 @@ module ModuleSync
         :namespace            => 'puppetlabs',
         :branch               => 'master',
         :git_user             => 'git',
+        :git_provider         => 'github',
         :git_provider_address => 'github.com',
         :managed_modules_conf => 'managed_modules.yml',
         :configs              => '.',


### PR DESCRIPTION
Small modifications to fit gitlab structure. It's working well with

- the modulesync.yml file as follow:

---
namespace: ''
branch: 'master'
git_base: 'https://<gitlab_url>'
git_provider: 'gitlab'
managed_modules_conf: 'managed_modules.yml'
configs: '.'

- the managed_modules.yml file would have following format:

---
- <gitlab_namespace>/<gitlab_project>
