### PR TITLE
Stop requiring .gitignore to exist in the repo

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -55,7 +55,12 @@ module ModuleSync
     # untracked under some circumstances
     # https://github.com/schacon/ruby-git/issues/130
     def self.untracked_unignored_files(repo)
-      ignored = File.open("#{repo.dir.path}/.gitignore").read.split
+      ignore_path = "#{repo.dir.path}/.gitignore"
+      if File.exists?(ignore_path)
+        ignored = File.open(ignore_path).read.split
+      else
+        ignored = []
+      end
       repo.status.untracked.keep_if{|f,_| !ignored.any?{|i| File.fnmatch(i, f)}}
     end
 


### PR DESCRIPTION
If a repo does not contain a .gitignore file, it is safe to assume the
git gem doesn't need to ignore extra files.