### PR TITLE
Pass puppet_module to ERB

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -63,6 +63,7 @@ module ModuleSync
         files_to_delete = []
         files_to_manage.each do |file|
           file_configs = (defaults[file] || {}).merge(module_configs[file] || {})
+          file_configs[:puppet_module] = puppet_module
           if file_configs['unmanaged']
             puts "Not managing #{file} in #{puppet_module}"
             files_to_delete << file


### PR DESCRIPTION
This allows to access the module name using
the @module variable.